### PR TITLE
feat: add window pixel width and height

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,8 @@ impl From<NonZeroU16> for OneBased {
 
 /// The dimensions of a terminal screen.
 ///
-/// For both Unix and Windows, Termina returns the width and height
+/// For both Unix and Windows, Termina returns the rows and columns.
+/// Pixel width and height are not supported on Windows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WindowSize {
     /// The width - the number of columns.
@@ -71,4 +72,8 @@ pub struct WindowSize {
     /// The height - the number of rows.
     #[doc(alias = "height")]
     pub rows: u16,
+    /// The height of the window in pixels.
+    pub pixel_width: Option<u16>,
+    /// The width of the window in pixels.
+    pub pixel_height: Option<u16>,
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -128,6 +128,8 @@ mod windows {
                         self.events.push_back(Event::WindowResized(WindowSize {
                             rows: rows.get(),
                             cols: cols.get(),
+                            pixel_width: None,
+                            pixel_height: None,
                         }));
                     }
                     _ => (),

--- a/src/terminal/unix.rs
+++ b/src/terminal/unix.rs
@@ -86,6 +86,8 @@ impl From<termios::Winsize> for WindowSize {
         Self {
             cols: size.ws_col,
             rows: size.ws_row,
+            pixel_width: Some(size.ws_xpixel),
+            pixel_height: Some(size.ws_ypixel),
         }
     }
 }

--- a/src/terminal/windows.rs
+++ b/src/terminal/windows.rs
@@ -256,6 +256,8 @@ impl OutputHandle {
         Ok(WindowSize {
             rows: rows.get(),
             cols: cols.get(),
+            pixel_width: None,
+            pixel_height: None,
         })
     }
 }


### PR DESCRIPTION
Adds support for the `xpixel` and `ypixel` values on Unix. I decided to use an `Option` here rather than set these to `0` on Windows because it more clearly conveys that these values aren't always supported, but I'm open to other ideas.