### PR TITLE
fix: ensure `try_read` always reads at least once

### DIFF
--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -82,7 +82,7 @@ impl EventSource for UnixEventSource {
     fn try_read(&mut self, timeout: Option<Duration>) -> io::Result<Option<Event>> {
         let timeout = PollTimeout::new(timeout);
 
-        while timeout.leftover().map_or(true, |t| !t.is_zero()) {
+        loop {
             if let Some(event) = self.parser.pop() {
                 return Ok(Some(event));
             }
@@ -135,6 +135,10 @@ impl EventSource for UnixEventSource {
                     io::ErrorKind::Interrupted,
                     "Poll operation was woken up",
                 ));
+            }
+
+            if timeout.leftover().is_some_and(|t| t.is_zero()) {
+                break;
             }
         }
 

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -41,7 +41,7 @@ impl EventSource for WindowsEventSource {
 
         let timeout = PollTimeout::new(timeout);
 
-        while timeout.leftover().map_or(true, |t| !t.is_zero()) {
+        loop {
             if let Some(event) = self.parser.pop() {
                 return Ok(Some(event));
             }
@@ -81,6 +81,10 @@ impl EventSource for WindowsEventSource {
             let records = self.input.read_console_input(pending)?;
 
             self.parser.decode_input_records(&records);
+
+            if timeout.leftover().is_some_and(|t| t.is_zero()) {
+                break;
+            }
         }
 
         Ok(None)


### PR DESCRIPTION
Currently, `terminal.poll(filter, Some(Duration::from_millis(0)))` will always return `false` because the while loop condition in `try_read` will always be false. Due to the small amount of time that will pass between calling `poll` and hitting the loop condition, a very small timeout like `Duration::from_nanos(1)` may also exhibit this same behavior. This changes it to behave like a do/while loop and always poll at least once.