### PR TITLE
fix: prevent subtraction with overflow when extended mouse coordinates are disabled

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -764,10 +764,11 @@ fn parse_csi_normal_mouse(buffer: &[u8]) -> Result<Option<Event>> {
     let (kind, modifiers) = parse_cb(cb)?;
 
     // See http://www.xfree86.org/current/ctlseqs.html#Mouse%20Tracking
-    // The upper left character position on the terminal is denoted as 1,1.
-    // Subtract 1 to keep it synced with cursor
-    let cx = u16::from(buffer[4].saturating_sub(32)) - 1;
-    let cy = u16::from(buffer[5].saturating_sub(32)) - 1;
+    // Mouse positions are encoded as (value + 32), but the upper left
+    // character position on the terminal is denoted as 1,1.
+    // So, we need to subtract 32 + 1 (33) to keep it synced with the cursor.
+    let cx = u16::from(buffer[4].saturating_sub(33));
+    let cy = u16::from(buffer[5].saturating_sub(33));
 
     Ok(Some(Event::Mouse(MouseEvent {
         kind,


### PR DESCRIPTION
When extended mouse coordinates (`SGRMouse`) are not enabled, mouse positions larger than 223 will be encoded as 0 in the input buffer. This causes the position calculation to panic with a "subtraction with overflow". The fix here is to use a saturating subtraction for the whole operation, which will cause the unsupported coordinates to show up as 0 rather than panicking.