### PR TITLE
feat: expose parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod terminal;
 use std::{fmt, num::NonZeroU16};
 
 pub use event::{reader::EventReader, Event};
+pub use parse::Parser;
 pub use terminal::{PlatformHandle, PlatformTerminal, Terminal};
 
 #[cfg(feature = "event-stream")]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -24,8 +24,9 @@ use crate::{
     style, Event,
 };
 
+/// A parser for ANSI escape sequences.
 #[derive(Debug)]
-pub(crate) struct Parser {
+pub struct Parser {
     buffer: Vec<u8>,
     /// Events which have been parsed. Pop out with `Self::pop`.
     events: VecDeque<Event>,
@@ -46,8 +47,10 @@ impl Parser {
         self.events.pop_front()
     }
 
-    // NOTE: Windows is handled in the `windows` module below.
-    #[cfg(unix)]
+    /// Parses additional data into the buffer.
+    /// Parsed events can be retrieved using [Parser::pop].
+    ///
+    /// `maybe_more` should be set to true if the input might be a partial sequence.
     pub fn parse(&mut self, bytes: &[u8], maybe_more: bool) {
         self.buffer.extend_from_slice(bytes);
         self.process_bytes(maybe_more);
@@ -96,7 +99,7 @@ mod windows {
     use super::*;
 
     impl Parser {
-        pub fn decode_input_records(&mut self, records: &[Console::INPUT_RECORD]) {
+        pub(crate) fn decode_input_records(&mut self, records: &[Console::INPUT_RECORD]) {
             for record in records {
                 match record.EventType as u32 {
                     Console::KEY_EVENT => {


### PR DESCRIPTION
Exposes the `Parser` struct along with the `parse` and `pop` methods (other methods remain private or `pub(crate)`). It's useful to have direct access to the parser for scenarios that require reading raw input data from external sources. For example, when running an [SSH server](https://docs.rs/russh/latest/russh/server/trait.Handler.html#method.data). 

Example usage with `russh` looks like this:

```rust
struct AppHandler {
    parser: Parser
}

impl Handler for AppHandler {
    async fn data(
        &mut self,
        _channel: ChannelId,
        data: &[u8],
        _session: &mut Session,
    ) -> Result<(), Self::Error> {
        self.parser.parse(data, false);
        while let Some(event) = self.parser.pop() {
            println!("{event:?}");
        }
    }
}