### PR TITLE
illumos uses poll

### DIFF
--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -190,6 +190,7 @@ fn poll(fds: [BorrowedFd<'_>; 3], timeout: Option<Duration>) -> std::io::Result<
         ])
     }
 
+    #[cfg(not(target_os = "illumos"))]
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     fn select2(fds: [BorrowedFd<'_>; 3], timeout: Option<&Timespec>) -> io::Result<[bool; 3]> {
         use rustix::event::{fd_set_insert, fd_set_num_elements, FdSetElement, FdSetIter};


### PR DESCRIPTION
This fixes a recent regression in helix on illumos due to unresolved imports.  The rustix crates points out that illumos recommends using `poll(2)` over `select(3c)` due to limitations around `FD_SETSIZE`.  

```
error[E0432]: unresolved imports `rustix::event::fd_set_insert`, `rustix::event::fd_set_num_elements`, `rustix::event::FdSetElement`, `rustix::event::FdSetIter`
   --> /home/link/.cargo/registry/src/index.crates.io-6f17d22bba15001f/termina-0.1.0/src/event/source/unix.rs:195:29
    |
195 |         use rustix::event::{fd_set_insert, fd_set_num_elements, FdSetElement, FdSetIter};
    |                             ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^ no `FdSetIter` in `event`
    |                             |              |                    |
    |                             |              |                    no `FdSetElement` in `event`
    |                             |              no `fd_set_num_elements` in `event`
    |                             no `fd_set_insert` in `event`

   Compiling gix-object v0.50.0
error[E0425]: cannot find function `select` in module `rustix::event`
   --> /home/link/.cargo/registry/src/index.crates.io-6f17d22bba15001f/termina-0.1.0/src/event/source/unix.rs:207:33
    |
207 |         unsafe { rustix::event::select(nfds, Some(&mut readfds), None, None, timeout) }?;
    |                                 ^^^^^^ not found in `rustix::event`
    |
note: found an item that was configured out
   --> /home/link/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustix-1.0.8/src/event/mod.rs:20:5
    |
20  | mod select;
    |     ^^^^^^
note: the item is gated here
   --> /home/link/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustix-1.0.8/src/event/mod.rs:19:1
    |
19  | #[cfg(any(bsd, linux_kernel, windows, target_os = "wasi"))]
```


Turns out `termina` uses poll by default outside of macOS, but we need to hide the select2 function from illumos builds.


```
❯ cargo t
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/termina-05df1f9664fda315)

running 13 tests
test base64::tests::encode_all_ascii ... ok
test base64::tests::encode_rfc4648_2 ... ok
test base64::tests::encode_rfc4648_1 ... ok
test base64::tests::encode_rfc4648_0 ... ok
test base64::tests::encode_rfc4648_5 ... ok
test base64::tests::encode_rfc4648_6 ... ok
test base64::tests::encode_all_bytes ... ok
test base64::tests::encode_rfc4648_4 ... ok
test base64::tests::encode_rfc4648_3 ... ok
test escape::dcs::test::encoding ... ok
test escape::csi::test::encoding ... ok
test parse::test::parse_dcs_sgr_response ... ok
test escape::csi::test::sgr_attributes_csi_param_limit ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests termina

running 3 tests
test src/style.rs - style::Stylized (line 232) ... ok
test src/escape/csi.rs - escape::csi::SgrAttributes (line 336) ... ok
test src/escape/csi.rs - escape::csi::SgrAttributes::is_empty (line 398) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
```