### PR TITLE
Added kitty multicursor support

### DIFF
--- a/src/escape/csi.rs
+++ b/src/escape/csi.rs
@@ -595,6 +595,15 @@ pub enum Cursor {
 
     /// Response to cursor shape query (kitty multi-cursor protocol).
     CursorShapeQueryResponse(Vec<u8>),
+
+    SetMultipleCursors {
+        /// Cursor shape (29 = follow main cursor shape)
+        shape: u8,
+        /// List of cursor positions (line, col) 1-indexed
+        positions: Vec<(u16, u16)>,
+    },
+
+    ClearSecondaryCursors,
 }
 
 impl Display for Cursor {
@@ -661,6 +670,14 @@ impl Display for Cursor {
                 }
                 write!(f, " q")
             }
+            Cursor::SetMultipleCursors { shape, positions } => {
+                write!(f, ">{}", shape)?;
+                for (line, col) in positions {
+                    write!(f, ";2:{}:{}", line, col)?;
+                }
+                write!(f, " q")
+            }
+            Cursor::ClearSecondaryCursors => write!(f, ">0;4 q"),
         }
     }
 }

--- a/src/escape/csi.rs
+++ b/src/escape/csi.rs
@@ -456,7 +456,7 @@ impl Default for SgrModifiers {
 
 // Cursor
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Cursor {
     /// CBT Moves cursor to the Ps tabs backward. The default value of Ps is 1.
     BackwardTabulation(u32),
@@ -592,6 +592,9 @@ pub enum Cursor {
     },
 
     CursorStyle(CursorStyle),
+
+    /// Response to cursor shape query (kitty multi-cursor protocol).
+    CursorShapeQueryResponse(Vec<u8>),
 }
 
 impl Display for Cursor {
@@ -648,6 +651,16 @@ impl Display for Cursor {
                 }
             }
             Cursor::CursorStyle(style) => write!(f, "{} q", *style as u8),
+            Cursor::CursorShapeQueryResponse(shapes) => {
+                write!(f, ">")?;
+                for (i, shape) in shapes.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ";")?;
+                    }
+                    write!(f, "{}", shape)?;
+                }
+                write!(f, " q")
+            }
         }
     }
 }

--- a/src/escape/csi.rs
+++ b/src/escape/csi.rs
@@ -456,6 +456,35 @@ impl Default for SgrModifiers {
 
 // Cursor
 
+/// The cursor shape for the kitty multi-cursor protocol.
+/// This represents either a specific `CursorStyle` (protocol values 0-6)
+/// or the special "follow main cursor" value (protocol value 29).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MultiCursorShape {
+    Style(CursorStyle),
+    FollowMainCursor,
+}
+
+impl MultiCursorShape {
+    pub fn protocol_value(&self) -> u8 {
+        match self {
+            Self::Style(style) => *style as u8,
+            Self::FollowMainCursor => 29,
+        }
+    }
+}
+
+impl TryFrom<u8> for MultiCursorShape {
+    type Error = u8;
+
+    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+        match value {
+            29 => Ok(Self::FollowMainCursor),
+            _ => CursorStyle::try_from(value).map(Self::Style),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Cursor {
     /// CBT Moves cursor to the Ps tabs backward. The default value of Ps is 1.
@@ -592,15 +621,14 @@ pub enum Cursor {
     },
 
     CursorStyle(CursorStyle),
+    QueryCursorShape,
 
     /// Response to cursor shape query (kitty multi-cursor protocol).
-    CursorShapeQueryResponse(Vec<u8>),
+    CursorShapeQueryResponse(Vec<CursorStyle>),
 
     SetMultipleCursors {
-        /// Cursor shape (29 = follow main cursor shape)
-        shape: u8,
-        /// List of cursor positions (line, col) 1-indexed
-        positions: Vec<(u16, u16)>,
+        shape: MultiCursorShape,
+        positions: Vec<(OneBased, OneBased)>,
     },
 
     ClearSecondaryCursors,
@@ -660,18 +688,19 @@ impl Display for Cursor {
                 }
             }
             Cursor::CursorStyle(style) => write!(f, "{} q", *style as u8),
-            Cursor::CursorShapeQueryResponse(shapes) => {
+            Cursor::QueryCursorShape => write!(f, "> q"),
+            Cursor::CursorShapeQueryResponse(styles) => {
                 write!(f, ">")?;
-                for (i, shape) in shapes.iter().enumerate() {
+                for (i, style) in styles.iter().enumerate() {
                     if i > 0 {
                         write!(f, ";")?;
                     }
-                    write!(f, "{}", shape)?;
+                    write!(f, "{}", *style as u8)?;
                 }
                 write!(f, " q")
             }
             Cursor::SetMultipleCursors { shape, positions } => {
-                write!(f, ">{}", shape)?;
+                write!(f, ">{}", shape.protocol_value())?;
                 for (line, col) in positions {
                     write!(f, ";2:{}:{}", line, col)?;
                 }
@@ -1548,5 +1577,73 @@ mod test {
         // sequence up in the middle: that would make it nonsense.
         attributes.parameter_chunk_size = NonZeroU16::new(12).unwrap();
         assert_eq!(expected, Csi::Sgr(Sgr::Attributes(attributes)).to_string());
+    }
+
+    #[test]
+    fn multi_cursor_encoding() {
+        // QueryCursorShape
+        assert_eq!(
+            "\x1b[> q",
+            Csi::Cursor(Cursor::QueryCursorShape).to_string()
+        );
+
+        // CursorShapeQueryResponse with typed CursorStyle values
+        assert_eq!(
+            "\x1b[>2;4 q",
+            Csi::Cursor(Cursor::CursorShapeQueryResponse(vec![
+                CursorStyle::SteadyBlock,
+                CursorStyle::SteadyUnderline,
+            ]))
+            .to_string()
+        );
+
+        // SetMultipleCursors with MultiCursorShape::FollowMainCursor
+        assert_eq!(
+            "\x1b[>29;2:1:1;2:2:5 q",
+            Csi::Cursor(Cursor::SetMultipleCursors {
+                shape: MultiCursorShape::FollowMainCursor,
+                positions: vec![
+                    (OneBased::new(1).unwrap(), OneBased::new(1).unwrap()),
+                    (OneBased::new(2).unwrap(), OneBased::new(5).unwrap()),
+                ],
+            })
+            .to_string()
+        );
+
+        // SetMultipleCursors with MultiCursorShape::Style
+        assert_eq!(
+            "\x1b[>2;2:3:10 q",
+            Csi::Cursor(Cursor::SetMultipleCursors {
+                shape: MultiCursorShape::Style(CursorStyle::SteadyBlock),
+                positions: vec![
+                    (OneBased::new(3).unwrap(), OneBased::new(10).unwrap()),
+                ],
+            })
+            .to_string()
+        );
+
+        // ClearSecondaryCursors
+        assert_eq!(
+            "\x1b[>0;4 q",
+            Csi::Cursor(Cursor::ClearSecondaryCursors).to_string()
+        );
+    }
+
+    #[test]
+    fn multi_cursor_shape_try_from() {
+        assert_eq!(
+            MultiCursorShape::try_from(0),
+            Ok(MultiCursorShape::Style(CursorStyle::Default))
+        );
+        assert_eq!(
+            MultiCursorShape::try_from(2),
+            Ok(MultiCursorShape::Style(CursorStyle::SteadyBlock))
+        );
+        assert_eq!(
+            MultiCursorShape::try_from(29),
+            Ok(MultiCursorShape::FollowMainCursor)
+        );
+        assert_eq!(MultiCursorShape::try_from(7), Err(7));
+        assert_eq!(MultiCursorShape::try_from(28), Err(28));
     }
 }

--- a/src/escape/csi.rs
+++ b/src/escape/csi.rs
@@ -1686,9 +1686,7 @@ mod test {
             "\x1b[>2;2:3:10 q",
             Csi::Cursor(Cursor::SetMultipleCursors {
                 shape: MultiCursorShape::Style(CursorStyle::SteadyBlock),
-                positions: vec![
-                    (OneBased::new(3).unwrap(), OneBased::new(10).unwrap()),
-                ],
+                positions: vec![(OneBased::new(3).unwrap(), OneBased::new(10).unwrap()),],
             })
             .to_string()
         );

--- a/src/escape/csi.rs
+++ b/src/escape/csi.rs
@@ -485,6 +485,63 @@ impl TryFrom<u8> for MultiCursorShape {
     }
 }
 
+/// Supported operations in the kitty multi-cursor protocol.
+///
+/// Returned in the capability query response (`CSI > SP q`). Each variant
+/// corresponds to a protocol operation code the terminal advertises support for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MultiCursorCapability {
+    /// Block cursor shape (code 1).
+    BlockShape,
+    /// Beam cursor shape (code 2).
+    BeamShape,
+    /// Underline cursor shape (code 3).
+    UnderlineShape,
+    /// Follow the main cursor's shape (code 29).
+    FollowMainCursorShape,
+    /// Change the color of text under extra cursors (code 30).
+    TextColor,
+    /// Change the color of extra cursors (code 40).
+    CursorColor,
+    /// Query currently set cursors (code 100).
+    QueryCurrentCursors,
+    /// Query extra cursor colors (code 101).
+    QueryColors,
+}
+
+impl MultiCursorCapability {
+    pub fn code(self) -> u8 {
+        match self {
+            Self::BlockShape => 1,
+            Self::BeamShape => 2,
+            Self::UnderlineShape => 3,
+            Self::FollowMainCursorShape => 29,
+            Self::TextColor => 30,
+            Self::CursorColor => 40,
+            Self::QueryCurrentCursors => 100,
+            Self::QueryColors => 101,
+        }
+    }
+}
+
+impl TryFrom<u8> for MultiCursorCapability {
+    type Error = u8;
+
+    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::BlockShape),
+            2 => Ok(Self::BeamShape),
+            3 => Ok(Self::UnderlineShape),
+            29 => Ok(Self::FollowMainCursorShape),
+            30 => Ok(Self::TextColor),
+            40 => Ok(Self::CursorColor),
+            100 => Ok(Self::QueryCurrentCursors),
+            101 => Ok(Self::QueryColors),
+            _ => Err(value),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Cursor {
     /// CBT Moves cursor to the Ps tabs backward. The default value of Ps is 1.
@@ -623,8 +680,11 @@ pub enum Cursor {
     CursorStyle(CursorStyle),
     QueryCursorShape,
 
-    /// Response to cursor shape query (kitty multi-cursor protocol).
-    CursorShapeQueryResponse(Vec<CursorStyle>),
+    /// Capability query response (kitty multi-cursor protocol).
+    ///
+    /// Contains the set of operations the terminal supports. An empty list
+    /// means the protocol is not supported.
+    CursorShapeQueryResponse(Vec<MultiCursorCapability>),
 
     SetMultipleCursors {
         shape: MultiCursorShape,
@@ -689,13 +749,13 @@ impl Display for Cursor {
             }
             Cursor::CursorStyle(style) => write!(f, "{} q", *style as u8),
             Cursor::QueryCursorShape => write!(f, "> q"),
-            Cursor::CursorShapeQueryResponse(styles) => {
+            Cursor::CursorShapeQueryResponse(caps) => {
                 write!(f, ">")?;
-                for (i, style) in styles.iter().enumerate() {
+                for (i, cap) in caps.iter().enumerate() {
                     if i > 0 {
                         write!(f, ";")?;
                     }
-                    write!(f, "{}", *style as u8)?;
+                    write!(f, "{}", cap.code())?;
                 }
                 write!(f, " q")
             }
@@ -1587,12 +1647,14 @@ mod test {
             Csi::Cursor(Cursor::QueryCursorShape).to_string()
         );
 
-        // CursorShapeQueryResponse with typed CursorStyle values
+        // CursorShapeQueryResponse with capability codes
         assert_eq!(
-            "\x1b[>2;4 q",
+            "\x1b[>1;2;29;100 q",
             Csi::Cursor(Cursor::CursorShapeQueryResponse(vec![
-                CursorStyle::SteadyBlock,
-                CursorStyle::SteadyUnderline,
+                MultiCursorCapability::BlockShape,
+                MultiCursorCapability::BeamShape,
+                MultiCursorCapability::FollowMainCursorShape,
+                MultiCursorCapability::QueryCurrentCursors,
             ]))
             .to_string()
         );

--- a/src/escape/csi.rs
+++ b/src/escape/csi.rs
@@ -465,15 +465,6 @@ pub enum MultiCursorShape {
     FollowMainCursor,
 }
 
-impl MultiCursorShape {
-    pub fn protocol_value(&self) -> u8 {
-        match self {
-            Self::Style(style) => *style as u8,
-            Self::FollowMainCursor => 29,
-        }
-    }
-}
-
 impl TryFrom<u8> for MultiCursorShape {
     type Error = u8;
 
@@ -491,37 +482,22 @@ impl TryFrom<u8> for MultiCursorShape {
 /// corresponds to a protocol operation code the terminal advertises support for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MultiCursorCapability {
-    /// Block cursor shape (code 1).
-    BlockShape,
-    /// Beam cursor shape (code 2).
-    BeamShape,
-    /// Underline cursor shape (code 3).
-    UnderlineShape,
-    /// Follow the main cursor's shape (code 29).
-    FollowMainCursorShape,
-    /// Change the color of text under extra cursors (code 30).
-    TextColor,
-    /// Change the color of extra cursors (code 40).
-    CursorColor,
-    /// Query currently set cursors (code 100).
-    QueryCurrentCursors,
-    /// Query extra cursor colors (code 101).
-    QueryColors,
-}
-
-impl MultiCursorCapability {
-    pub fn code(self) -> u8 {
-        match self {
-            Self::BlockShape => 1,
-            Self::BeamShape => 2,
-            Self::UnderlineShape => 3,
-            Self::FollowMainCursorShape => 29,
-            Self::TextColor => 30,
-            Self::CursorColor => 40,
-            Self::QueryCurrentCursors => 100,
-            Self::QueryColors => 101,
-        }
-    }
+    /// Block cursor shape.
+    BlockShape = 1,
+    /// Beam cursor shape.
+    BeamShape = 2,
+    /// Underline cursor shape.
+    UnderlineShape = 3,
+    /// Follow the main cursor's shape.
+    FollowMainCursorShape = 29,
+    /// Change the color of text under extra cursors.
+    TextColor = 30,
+    /// Change the color of extra cursors.
+    CursorColor = 40,
+    /// Query currently set cursors.
+    QueryCurrentCursors = 100,
+    /// Query extra cursor colors.
+    QueryColors = 101,
 }
 
 impl TryFrom<u8> for MultiCursorCapability {
@@ -764,12 +740,19 @@ impl Display for Cursor {
                     if i > 0 {
                         write!(f, ";")?;
                     }
-                    write!(f, "{}", cap.code())?;
+                    write!(f, "{}", *cap as u8)?;
                 }
                 write!(f, " q")
             }
             Cursor::SetMultipleCursors { shape, positions } => {
-                write!(f, ">{}", shape.protocol_value())?;
+                write!(
+                    f,
+                    ">{}",
+                    match shape {
+                        MultiCursorShape::Style(style) => *style as u8,
+                        MultiCursorShape::FollowMainCursor => 29,
+                    }
+                )?;
                 for (line, col) in positions {
                     write!(f, ";2:{}:{}", line, col)?;
                 }

--- a/src/escape/csi.rs
+++ b/src/escape/csi.rs
@@ -465,17 +465,6 @@ pub enum MultiCursorShape {
     FollowMainCursor,
 }
 
-impl TryFrom<u8> for MultiCursorShape {
-    type Error = u8;
-
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
-        match value {
-            29 => Ok(Self::FollowMainCursor),
-            _ => CursorStyle::try_from(value).map(Self::Style),
-        }
-    }
-}
-
 /// Supported operations in the kitty multi-cursor protocol.
 ///
 /// Returned in the capability query response (`CSI > SP q`). Each variant
@@ -1679,23 +1668,5 @@ mod test {
             "\x1b[>0;4 q",
             Csi::Cursor(Cursor::ClearSecondaryCursors).to_string()
         );
-    }
-
-    #[test]
-    fn multi_cursor_shape_try_from() {
-        assert_eq!(
-            MultiCursorShape::try_from(0),
-            Ok(MultiCursorShape::Style(CursorStyle::Default))
-        );
-        assert_eq!(
-            MultiCursorShape::try_from(2),
-            Ok(MultiCursorShape::Style(CursorStyle::SteadyBlock))
-        );
-        assert_eq!(
-            MultiCursorShape::try_from(29),
-            Ok(MultiCursorShape::FollowMainCursor)
-        );
-        assert_eq!(MultiCursorShape::try_from(7), Err(7));
-        assert_eq!(MultiCursorShape::try_from(28), Err(28));
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -934,7 +934,7 @@ fn parse_csi_cursor_shape_query_response(buffer: &[u8]) -> Result<Option<Event>>
                     csi::MultiCursorCapability::try_from(v).map_err(|_| MalformedSequenceError)
                 })
         })
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(Some(Event::Csi(Csi::Cursor(
         csi::Cursor::CursorShapeQueryResponse(caps),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -927,20 +927,20 @@ fn parse_csi_cursor_shape_query_response(buffer: &[u8]) -> Result<Option<Event>>
         ))));
     }
 
-    let styles: Vec<style::CursorStyle> = s
+    let caps: Vec<csi::MultiCursorCapability> = s
         .split(';')
         .filter(|part| !part.is_empty())
         .map(|part| {
             part.parse::<u8>()
                 .map_err(|_| MalformedSequenceError)
                 .and_then(|v| {
-                    style::CursorStyle::try_from(v).map_err(|_| MalformedSequenceError)
+                    csi::MultiCursorCapability::try_from(v).map_err(|_| MalformedSequenceError)
                 })
         })
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
     Ok(Some(Event::Csi(Csi::Cursor(
-        csi::Cursor::CursorShapeQueryResponse(styles),
+        csi::Cursor::CursorShapeQueryResponse(caps),
     ))))
 }
 
@@ -1235,31 +1235,34 @@ mod test {
 
     #[test]
     fn parse_cursor_shape_query_response() {
-        // CSI > 2 ; 4 SP q is a response with SteadyBlock and SteadyUnderline.
-        let event = parse_event(b"\x1b[>2;4 q", false).unwrap().unwrap();
+        // Kitty responds with the supported operation codes.
+        let event = parse_event(b"\x1b[>1;2;29;100 q", false).unwrap().unwrap();
         assert_eq!(
             event,
             Event::Csi(Csi::Cursor(csi::Cursor::CursorShapeQueryResponse(vec![
-                style::CursorStyle::SteadyBlock,
-                style::CursorStyle::SteadyUnderline,
+                csi::MultiCursorCapability::BlockShape,
+                csi::MultiCursorCapability::BeamShape,
+                csi::MultiCursorCapability::FollowMainCursorShape,
+                csi::MultiCursorCapability::QueryCurrentCursors,
             ])))
         );
     }
 
     #[test]
     fn parse_cursor_shape_query_response_invalid() {
-        // Value 7 is not a valid CursorStyle.
+        // Value 7 is not a valid MultiCursorCapability code.
         assert!(parse_event(b"\x1b[>7 q", false).is_err());
     }
 
     #[test]
     fn cursor_shape_query_response_round_trip() {
         let response = csi::Cursor::CursorShapeQueryResponse(vec![
-            style::CursorStyle::SteadyBlock,
-            style::CursorStyle::BlinkingBar,
+            csi::MultiCursorCapability::BlockShape,
+            csi::MultiCursorCapability::FollowMainCursorShape,
+            csi::MultiCursorCapability::QueryCurrentCursors,
         ]);
         let encoded = Csi::Cursor(response.clone()).to_string();
-        assert_eq!(encoded, "\x1b[>2;5 q");
+        assert_eq!(encoded, "\x1b[>1;29;100 q");
 
         let parsed = parse_event(encoded.as_bytes(), false).unwrap().unwrap();
         assert_eq!(parsed, Event::Csi(Csi::Cursor(response)));

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -920,15 +920,27 @@ fn parse_csi_cursor_shape_query_response(buffer: &[u8]) -> Result<Option<Event>>
 
     let s = str::from_utf8(&buffer[3..buffer.len() - 2])?;
 
-    let shapes: Vec<u8> = s
+    // An empty parameter string (CSI > SP q) is a query.
+    if s.is_empty() {
+        return Ok(Some(Event::Csi(Csi::Cursor(
+            csi::Cursor::QueryCursorShape,
+        ))));
+    }
+
+    let styles: Vec<style::CursorStyle> = s
         .split(';')
         .filter(|part| !part.is_empty())
-        .map(|part| part.parse::<u8>())
-        .collect::<std::result::Result<Vec<u8>, _>>()
-        .map_err(|_| MalformedSequenceError)?;
+        .map(|part| {
+            part.parse::<u8>()
+                .map_err(|_| MalformedSequenceError)
+                .and_then(|v| {
+                    style::CursorStyle::try_from(v).map_err(|_| MalformedSequenceError)
+                })
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
     Ok(Some(Event::Csi(Csi::Cursor(
-        csi::Cursor::CursorShapeQueryResponse(shapes),
+        csi::Cursor::CursorShapeQueryResponse(styles),
     ))))
 }
 
@@ -1209,5 +1221,47 @@ mod test {
                 ])
             })
         );
+    }
+
+    #[test]
+    fn parse_cursor_shape_query() {
+        // CSI > SP q with no parameters is a query.
+        let event = parse_event(b"\x1b[> q", false).unwrap().unwrap();
+        assert_eq!(
+            event,
+            Event::Csi(Csi::Cursor(csi::Cursor::QueryCursorShape))
+        );
+    }
+
+    #[test]
+    fn parse_cursor_shape_query_response() {
+        // CSI > 2 ; 4 SP q is a response with SteadyBlock and SteadyUnderline.
+        let event = parse_event(b"\x1b[>2;4 q", false).unwrap().unwrap();
+        assert_eq!(
+            event,
+            Event::Csi(Csi::Cursor(csi::Cursor::CursorShapeQueryResponse(vec![
+                style::CursorStyle::SteadyBlock,
+                style::CursorStyle::SteadyUnderline,
+            ])))
+        );
+    }
+
+    #[test]
+    fn parse_cursor_shape_query_response_invalid() {
+        // Value 7 is not a valid CursorStyle.
+        assert!(parse_event(b"\x1b[>7 q", false).is_err());
+    }
+
+    #[test]
+    fn cursor_shape_query_response_round_trip() {
+        let response = csi::Cursor::CursorShapeQueryResponse(vec![
+            style::CursorStyle::SteadyBlock,
+            style::CursorStyle::BlinkingBar,
+        ]);
+        let encoded = Csi::Cursor(response.clone()).to_string();
+        assert_eq!(encoded, "\x1b[>2;5 q");
+
+        let parsed = parse_event(encoded.as_bytes(), false).unwrap().unwrap();
+        assert_eq!(parsed, Event::Csi(Csi::Cursor(response)));
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -53,23 +53,6 @@ impl Display for CursorStyle {
     }
 }
 
-impl TryFrom<u8> for CursorStyle {
-    type Error = u8;
-
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::Default),
-            1 => Ok(Self::BlinkingBlock),
-            2 => Ok(Self::SteadyBlock),
-            3 => Ok(Self::BlinkingUnderline),
-            4 => Ok(Self::SteadyUnderline),
-            5 => Ok(Self::BlinkingBar),
-            6 => Ok(Self::SteadyBar),
-            _ => Err(value),
-        }
-    }
-}
-
 /// An 8-bit "256-color".
 ///
 /// Colors 0-15 are the same as `AnsiColor`s (0-7 being normal colors and 8-15 being "bright").
@@ -454,23 +437,5 @@ mod test {
         assert_eq!("#282828".parse(), Ok(RgbColor::new(40, 40, 40)));
         assert_eq!("rgb:28/28/28".parse(), Ok(RgbColor::new(40, 40, 40)));
         assert_eq!("rgb:2828/2828/2828".parse(), Ok(RgbColor::new(40, 40, 40)));
-    }
-
-    #[test]
-    fn cursor_style_try_from_valid() {
-        assert_eq!(CursorStyle::try_from(0), Ok(CursorStyle::Default));
-        assert_eq!(CursorStyle::try_from(1), Ok(CursorStyle::BlinkingBlock));
-        assert_eq!(CursorStyle::try_from(2), Ok(CursorStyle::SteadyBlock));
-        assert_eq!(CursorStyle::try_from(3), Ok(CursorStyle::BlinkingUnderline));
-        assert_eq!(CursorStyle::try_from(4), Ok(CursorStyle::SteadyUnderline));
-        assert_eq!(CursorStyle::try_from(5), Ok(CursorStyle::BlinkingBar));
-        assert_eq!(CursorStyle::try_from(6), Ok(CursorStyle::SteadyBar));
-    }
-
-    #[test]
-    fn cursor_style_try_from_invalid() {
-        assert_eq!(CursorStyle::try_from(7), Err(7));
-        assert_eq!(CursorStyle::try_from(29), Err(29));
-        assert_eq!(CursorStyle::try_from(255), Err(255));
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -52,6 +52,23 @@ impl Display for CursorStyle {
     }
 }
 
+impl TryFrom<u8> for CursorStyle {
+    type Error = u8;
+
+    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Default),
+            1 => Ok(Self::BlinkingBlock),
+            2 => Ok(Self::SteadyBlock),
+            3 => Ok(Self::BlinkingUnderline),
+            4 => Ok(Self::SteadyUnderline),
+            5 => Ok(Self::BlinkingBar),
+            6 => Ok(Self::SteadyBar),
+            _ => Err(value),
+        }
+    }
+}
+
 /// An 8-bit "256-color".
 ///
 /// Colors 0-15 are the same as `AnsiColor`s (0-7 being normal colors and 8-15 being "bright").
@@ -352,5 +369,28 @@ impl StyleExt<'static> for String {
 impl<'a> StyleExt<'a> for Stylized<'a> {
     fn stylized(self) -> Stylized<'a> {
         self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cursor_style_try_from_valid() {
+        assert_eq!(CursorStyle::try_from(0), Ok(CursorStyle::Default));
+        assert_eq!(CursorStyle::try_from(1), Ok(CursorStyle::BlinkingBlock));
+        assert_eq!(CursorStyle::try_from(2), Ok(CursorStyle::SteadyBlock));
+        assert_eq!(CursorStyle::try_from(3), Ok(CursorStyle::BlinkingUnderline));
+        assert_eq!(CursorStyle::try_from(4), Ok(CursorStyle::SteadyUnderline));
+        assert_eq!(CursorStyle::try_from(5), Ok(CursorStyle::BlinkingBar));
+        assert_eq!(CursorStyle::try_from(6), Ok(CursorStyle::SteadyBar));
+    }
+
+    #[test]
+    fn cursor_style_try_from_invalid() {
+        assert_eq!(CursorStyle::try_from(7), Err(7));
+        assert_eq!(CursorStyle::try_from(29), Err(29));
+        assert_eq!(CursorStyle::try_from(255), Err(255));
     }
 }


### PR DESCRIPTION
Added CSI > parameter prefix parsing to support kitty multi-cursor protocol query responses.

Needed for https://github.com/helix-editor/helix/pull/14757