### PR TITLE
fix: don't rely on value from GetNumberOfConsoleInputEvents

### DIFF
--- a/docs/windows-vt.md
+++ b/docs/windows-vt.md
@@ -118,11 +118,10 @@ use windows_sys::Win32::System::Console::{
 };
 use std::mem;
 
-let mut num_to_read = 0;
-unsafe { GetNumberOfConsoleInputEvents(output.handle.as_raw_handle(), &mut num_to_read) };
-let mut records = Vec::with_capacity(num_to_read as usize);
+let mut capacity = 128;
+let mut records = Vec::with_capacity(capacity);
 let zeroed: INPUT_RECORD = unsafe { mem::zeroed() };
-records.resize(num_to_read as usize, zeroed);
+records.resize(capacity, zeroed);
 let mut num_read = 0;
 unsafe {
     ReadConsoleInputA(output.handle.as_raw_handle(), records.as_mut_ptr(), new_to_read, &mut num_read);


### PR DESCRIPTION
The value returned from `GetNumberOfConsoleInputEvents` matches what you would get when calling `ReadConsoleInputW`, but this does not always match the number of results from `ReadConsoleInputA` when typing some Unicode characters that differ in UTF-8/UTF-16 encoding. As a result, some Unicode characters were not fully read on the initial keystroke and did not show up until you typed them twice. Thankfully, `ReadConsoleInputA` tells us how many results are returned anyway, so we can just initialize it with a sufficiently large buffer and only use `GetNumberOfConsoleInputEvents` to determine if there are >0 pending events.

This should fix the reports from people claiming they had to type in certain keys more than once or some characters weren't appearing (https://github.com/helix-editor/helix/issues/14637#issuecomment-3442597137, https://github.com/helix-editor/helix/issues/14363#issuecomment-3266479258). I wasn't able to reproduce the IME input hanging (https://github.com/helix-editor/helix/issues/14387), so I'm not sure if this will be fixed, but it might.

The other issues on Windows, such as certain keys like `<Ctrl-,>` not working, will still require implementing the legacy protocol for some users, since Windows Terminal (among others) doesn't implement the Kitty Keyboard protocol. I'm working on this in another branch.