### PR TITLE
Add escape sequences for setting/clearing foreground & background colors

### DIFF
--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -1,0 +1,42 @@
+use std::io::{self, Write as _};
+
+use termina::{
+    escape::{
+        csi::{self, Csi},
+        osc::Osc,
+    },
+    PlatformTerminal, Terminal as _,
+};
+
+fn main() -> io::Result<()> {
+    let mut terminal = PlatformTerminal::new()?;
+    terminal.enter_raw_mode()?;
+
+    write!(
+        terminal,
+        "{}{}{}{}Check the green background/blue foreground of your terminal. Press any key to exit. ",
+        Csi::Mode(csi::Mode::SetDecPrivateMode(csi::DecPrivateMode::Code(
+            csi::DecPrivateModeCode::ClearAndEnableAlternateScreen
+        ))),
+        Osc::SetForegroundColor(128, 128, 255),
+        Osc::SetBackgroundColor(0, 64, 0),
+        Csi::Cursor(csi::Cursor::Position {
+            line: Default::default(),
+            col: Default::default(),
+        }),
+    )?;
+    terminal.flush()?;
+    let _ = terminal.read(|event| matches!(event, termina::Event::Key(_)));
+
+    write!(
+        terminal,
+        "{}{}{}",
+        Csi::Mode(csi::Mode::ResetDecPrivateMode(csi::DecPrivateMode::Code(
+            csi::DecPrivateModeCode::ClearAndEnableAlternateScreen,
+        ))),
+        Osc::ClearBackgroundColor,
+        Osc::ClearForegroundColor
+    )?;
+
+    Ok(())
+}

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -5,6 +5,7 @@ use termina::{
         csi::{self, Csi},
         osc::Osc,
     },
+    style::RgbColor,
     PlatformTerminal, Terminal as _,
 };
 
@@ -18,8 +19,8 @@ fn main() -> io::Result<()> {
         Csi::Mode(csi::Mode::SetDecPrivateMode(csi::DecPrivateMode::Code(
             csi::DecPrivateModeCode::ClearAndEnableAlternateScreen
         ))),
-        Osc::SetForegroundColor(128, 128, 255),
-        Osc::SetBackgroundColor(0, 64, 0),
+        Osc::SetForegroundColor(RgbColor::new(128, 128, 255)),
+        Osc::SetBackgroundColor(RgbColor::new(0, 64, 0)),
         Csi::Cursor(csi::Cursor::Position {
             line: Default::default(),
             col: Default::default(),

--- a/src/escape/osc.rs
+++ b/src/escape/osc.rs
@@ -15,6 +15,10 @@ pub enum Osc<'a> {
     ClearSelection(Selection),
     QuerySelection(Selection),
     SetSelection(Selection, &'a str),
+    SetBackgroundColor(u8, u8, u8),
+    SetForegroundColor(u8, u8, u8),
+    ClearBackgroundColor,
+    ClearForegroundColor,
     // TODO: I didn't copy many available commands yet...
 }
 
@@ -33,6 +37,10 @@ impl Display for Osc<'_> {
                 // TODO: it'd be nice to avoid allocating a string to base64 encode.
                 write!(f, "52;{selection};{}", base64::encode(content.as_bytes()))?
             }
+            Self::SetForegroundColor(r, g, b) => write!(f, "10;#{:02x}{:02x}{:02x}", r, g, b)?,
+            Self::SetBackgroundColor(r, g, b) => write!(f, "11;#{:02x}{:02x}{:02x}", r, g, b)?,
+            Self::ClearForegroundColor => write!(f, "110")?,
+            Self::ClearBackgroundColor => write!(f, "111")?,
         }
         f.write_str(super::ST)?;
         Ok(())

--- a/src/escape/osc.rs
+++ b/src/escape/osc.rs
@@ -4,7 +4,7 @@
 
 use std::fmt::{self, Display};
 
-use crate::base64;
+use crate::{base64, style::RgbColor};
 
 pub enum Osc<'a> {
     SetIconNameAndWindowTitle(&'a str),
@@ -15,8 +15,8 @@ pub enum Osc<'a> {
     ClearSelection(Selection),
     QuerySelection(Selection),
     SetSelection(Selection, &'a str),
-    SetBackgroundColor(u8, u8, u8),
-    SetForegroundColor(u8, u8, u8),
+    SetBackgroundColor(RgbColor),
+    SetForegroundColor(RgbColor),
     ClearBackgroundColor,
     ClearForegroundColor,
     // TODO: I didn't copy many available commands yet...
@@ -37,8 +37,16 @@ impl Display for Osc<'_> {
                 // TODO: it'd be nice to avoid allocating a string to base64 encode.
                 write!(f, "52;{selection};{}", base64::encode(content.as_bytes()))?
             }
-            Self::SetForegroundColor(r, g, b) => write!(f, "10;#{:02x}{:02x}{:02x}", r, g, b)?,
-            Self::SetBackgroundColor(r, g, b) => write!(f, "11;#{:02x}{:02x}{:02x}", r, g, b)?,
+            Self::SetForegroundColor(color) => write!(
+                f,
+                "10;#{:02x}{:02x}{:02x}",
+                color.red, color.green, color.blue
+            )?,
+            Self::SetBackgroundColor(color) => write!(
+                f,
+                "11;#{:02x}{:02x}{:02x}",
+                color.red, color.green, color.blue
+            )?,
             Self::ClearForegroundColor => write!(f, "110")?,
             Self::ClearBackgroundColor => write!(f, "111")?,
         }


### PR DESCRIPTION
Prerequisite for https://github.com/helix-editor/helix/pull/15170
I've used https://ghostty.org/docs/vt/concepts/colors#color-specifications as a reference.

Thus far I've only added support for hexadecimal RGB with 8 bit color chanels. But this could be extended to support the other formats if desired.

See below screen recording (Ghostty v1.2.3 on MacOS Tahoe)

https://github.com/user-attachments/assets/0fced1f9-2993-4d26-9aae-c45f4ca0b6f8

